### PR TITLE
Fix Esser actor sheet rendering with Handlebars mixin

### DIFF
--- a/esser/module/esser.js
+++ b/esser/module/esser.js
@@ -10,7 +10,9 @@ Hooks.once("init", async function () {
   ActorsCollection.registerSheet("esser", EsserActorSheet, { types: ["character"], makeDefault: true });
 });
 
-class EsserActorSheet extends foundry.applications.sheets.ActorSheet {
+const { HandlebarsApplicationMixin } = foundry.applications.api;
+
+class EsserActorSheet extends HandlebarsApplicationMixin(foundry.applications.sheets.ActorSheet) {
   static DEFAULT_OPTIONS = foundry.utils.mergeObject(super.DEFAULT_OPTIONS, {
     classes: ["esser", "sheet", "actor"],
     position: { width: 720, height: 720 },

--- a/esser/system.json
+++ b/esser/system.json
@@ -3,7 +3,7 @@
   "title": "ESSER – Espen’s Super Simple Easy RPG",
   "type": "system",
   "description": "A rules-light, theatre-of-the-mind RPG system for Foundry VTT. d20 + bonuses, Strikes, and simple opposed combat.",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "compatibility": { "minimum": "13", "verified": "13" },
   "authors": [{ "name": "Espen + Codex" }],
   "url": "https://example.com/esser",


### PR DESCRIPTION
## Summary
- wrap the Esser actor sheet in Foundry's HandlebarsApplicationMixin so it implements the required rendering hooks
- bump the system manifest version to 0.1.4

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e039efce588328bd91d22ffcf1bb32