### PR TITLE
Fix strike adjustment clamp and roll evaluation

### DIFF
--- a/esser/module/esser.js
+++ b/esser/module/esser.js
@@ -64,15 +64,20 @@ class EsserActorSheet extends HandlebarsApplicationMixin(foundry.applications.sh
   }
 
   async _modStrikes(delta) {
-    const s = foundry.utils.clamp(this.actor.system.strikes + delta, 0, this.actor.system.maxStrikes ?? 3);
+    const maxStrikes = this.actor.system.maxStrikes ?? 3;
+    const s = clamp(this.actor.system.strikes + delta, 0, maxStrikes);
     await this.actor.update({ "system.strikes": s });
-    if (s >= (this.actor.system.maxStrikes ?? 3)) {
+    if (s >= maxStrikes) {
       ui.notifications.warn(`${this.actor.name} is OUT (3 Strikes).`);
     }
   }
 }
 
 // ---------- Helpers ----------
+function clamp(value, min, max) {
+  return Math.min(Math.max(value, min), max);
+}
+
 function skillList() {
   return {
     athletics: "Athletics", acrobatics: "Acrobatics", endurance: "Endurance", melee: "Melee",
@@ -87,7 +92,7 @@ function skillList() {
 
 export async function rollSkill(actor, skill, { flavor = "" } = {}) {
   const bonus = Number(actor.system.skills?.[skill] ?? 0);
-  const roll = await (new Roll(`1d20 + ${bonus}`)).roll({ async: true });
+  const roll = await (new Roll(`1d20 + ${bonus}`)).evaluate();
   const total = roll.total;
 
   // Results ladder

--- a/esser/system.json
+++ b/esser/system.json
@@ -3,7 +3,7 @@
   "title": "ESSER – Espen’s Super Simple Easy RPG",
   "type": "system",
   "description": "A rules-light, theatre-of-the-mind RPG system for Foundry VTT. d20 + bonuses, Strikes, and simple opposed combat.",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "compatibility": { "minimum": "13", "verified": "13" },
   "authors": [{ "name": "Espen + Codex" }],
   "url": "https://example.com/esser",


### PR DESCRIPTION
## Summary
- replace the removed `foundry.utils.clamp` usage with a local helper when adjusting strikes
- switch skill rolls to use `Roll#evaluate` to avoid the async option warning
- bump the system manifest version to 0.1.5

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68e03c1703e08328a5ecfedf44f9ac23