### PR TITLE
Update manifest for Foundry schema changes

### DIFF
--- a/esser/system.json
+++ b/esser/system.json
@@ -1,9 +1,8 @@
 {
   "id": "esser",
   "title": "ESSER – Espen’s Super Simple Easy RPG",
-  "type": "system",
   "description": "A rules-light, theatre-of-the-mind RPG system for Foundry VTT. d20 + bonuses, Strikes, and simple opposed combat.",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "compatibility": { "minimum": "13", "verified": "13" },
   "authors": [{ "name": "Espen + Codex" }],
   "url": "https://example.com/esser",
@@ -12,6 +11,7 @@
   "languages": [{ "lang": "en", "name": "English", "path": "lang/en.json" }],
   "packs": [
     {
+      "name": "adventure-frames",
       "label": "ESSER Adventure Frames",
       "type": "Scene",
       "path": "packs/adventure-frames.db",
@@ -19,8 +19,14 @@
       "private": false
     }
   ],
-  "gridDistance": 1,
-  "gridUnits": "unit",
+  "grid": {
+    "distance": 1,
+    "units": "unit"
+  },
   "primaryTokenAttribute": null,
-  "styles": ["styles/esser.css"]
+  "styles": [
+    {
+      "src": "styles/esser.css"
+    }
+  ]
 }


### PR DESCRIPTION
## Summary
- update the system manifest to the current Foundry schema by using the new grid object and structured style definition
- add the missing compendium pack name and remove the deprecated `type` field
- bump the system version to 0.1.6 for the release metadata update

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68e03d84b17483288dca373f538e2444