### PR TITLE
Add attribute-driven skill training UI

### DIFF
--- a/esser/lang/en.json
+++ b/esser/lang/en.json
@@ -3,6 +3,8 @@
   "ESSER.Strikes": "Strikes",
   "ESSER.Skills": "Skills",
   "ESSER.SkillsHint": "Adjust bonuses and click the die to roll when adventure calls.",
+  "ESSER.Attributes": "Attributes & Skills",
+  "ESSER.AttributesHint": "Assign your core strengths, then choose a training level for each linked skill.",
   "ESSER.RollSkill": "Roll {{label}}",
   "ESSER.Notes": "Notes",
   "ESSER.NotesPlaceholder": "Background beats, allies, goals, scars, and reminders all live here.",
@@ -19,5 +21,23 @@
     "perception": "Perception", "healing": "Healing", "animal": "Animal Handling",
     "spell_arcane": "Spellcasting (Arcane)", "spell_divine": "Spellcasting (Divine)",
     "spell_occult": "Spellcasting (Occult)", "spell_primal": "Spellcasting (Primal)"
+  },
+  "ESSER.Attribute": {
+    "might": "Might",
+    "agility": "Agility",
+    "mind": "Mind",
+    "charm": "Charm"
+  },
+  "ESSER.AttributeDescription": {
+    "might": "Strength, endurance, and prowess in melee challenges.",
+    "agility": "Dexterity, speed, stealth, and ranged attacks.",
+    "mind": "Intelligence, lore mastery, survival, and spellcraft.",
+    "charm": "Persuasion, trickery, animal bonds, and social presence."
+  },
+  "ESSER.SkillRank": {
+    "untrained": "Untrained (+0)",
+    "skilled": "Skilled (+2)",
+    "expert": "Expert (+4)",
+    "master": "Master (+6)"
   }
 }

--- a/esser/styles/esser.css
+++ b/esser/styles/esser.css
@@ -17,6 +17,15 @@
   backdrop-filter: blur(4px);
 }
 
+.esser-sheet .sheet-body {
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+  flex: 1;
+  overflow-y: auto;
+  padding-right: 6px;
+}
+
 .card {
   background: var(--esser-card-bg);
   border: 1px solid var(--esser-card-border);
@@ -246,10 +255,59 @@
   color: rgba(15, 23, 42, 0.55);
 }
 
-.skills {
+.attributes {
   padding: 20px;
   display: flex;
   flex-direction: column;
+}
+
+.attribute-groups {
+  display: grid;
+  gap: 16px;
+}
+
+.attribute-block {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  padding: 16px;
+  border-radius: 14px;
+  background: rgba(15, 23, 42, 0.03);
+  box-shadow: inset 0 0 0 1px rgba(15, 23, 42, 0.08);
+}
+
+.attribute-header {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.attribute-meta {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.attribute-label {
+  font-size: 1.05rem;
+  font-weight: 700;
+  color: rgba(15, 23, 42, 0.85);
+}
+
+.attribute-select {
+  min-width: 84px;
+  border: 1px solid rgba(15, 23, 42, 0.2);
+  border-radius: 10px;
+  padding: 6px 8px;
+  font-weight: 600;
+  background: rgba(255, 255, 255, 0.92);
+}
+
+.attribute-description {
+  margin: 0;
+  font-size: 0.85rem;
+  color: rgba(15, 23, 42, 0.6);
 }
 
 .skills-grid {
@@ -259,7 +317,7 @@
 
 .skill-row {
   display: grid;
-  grid-template-columns: 44px 1fr minmax(70px, 90px);
+  grid-template-columns: 44px 1fr minmax(120px, 150px);
   align-items: center;
   gap: 12px;
   padding: 10px 12px;
@@ -312,14 +370,14 @@
   color: rgba(15, 23, 42, 0.45);
 }
 
-.skill-input {
+.skill-select {
   width: 100%;
   border: 1px solid rgba(15, 23, 42, 0.2);
   border-radius: 10px;
   padding: 6px 8px;
-  text-align: center;
   font-weight: 600;
-  font-size: 1rem;
+  font-size: 0.95rem;
+  background: rgba(255, 255, 255, 0.92);
 }
 
 .notes {
@@ -364,6 +422,10 @@
   .sheet-columns {
     grid-template-columns: 1fr;
   }
+
+  .attribute-groups {
+    gap: 12px;
+  }
 }
 
 @media (max-width: 640px) {
@@ -377,6 +439,6 @@
   }
 
   .skill-row {
-    grid-template-columns: 40px 1fr 70px;
+    grid-template-columns: 40px 1fr 110px;
   }
 }

--- a/esser/system.json
+++ b/esser/system.json
@@ -2,7 +2,7 @@
   "id": "esser",
   "title": "ESSER – Espen’s Super Simple Easy RPG",
   "description": "A rules-light, theatre-of-the-mind RPG system for Foundry VTT. d20 + bonuses, Strikes, and simple opposed combat.",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "compatibility": { "minimum": "13", "verified": "13" },
   "authors": [{ "name": "Espen + Codex" }],
   "url": "https://example.com/esser",

--- a/esser/template.json
+++ b/esser/template.json
@@ -7,6 +7,12 @@
         "notes": "",
         "strikes": 0,
         "maxStrikes": 3,
+        "attributes": {
+          "might": 2,
+          "agility": 1,
+          "mind": 0,
+          "charm": 0
+        },
         "skills": {
           "athletics": 0, "acrobatics": 0, "endurance": 0, "melee": 0, "ranged": 0, "unarmed": 0, "stealth": 0, "thievery": 0,
           "nature": 0, "survival": 0, "crafting": 0, "lore": 0,

--- a/esser/templates/actor/actor-sheet.hbs
+++ b/esser/templates/actor/actor-sheet.hbs
@@ -65,32 +65,52 @@
     </header>
 
     <section class="sheet-columns">
-      <section class="skills card">
+      <section class="attributes card">
         <header class="section-header">
-          <h2>{{localize "ESSER.Skills"}}</h2>
-          <p>{{localize "ESSER.SkillsHint"}}</p>
+          <h2>{{localize "ESSER.Attributes"}}</h2>
+          <p>{{localize "ESSER.AttributesHint"}}</p>
         </header>
-        <div class="skills-grid">
-          {{#each skills}}
-          <div class="skill-row">
-            <button
-              type="button"
-              class="roll-button"
-              data-action="roll-skill"
-              data-skill="{{this.key}}"
-              aria-label="{{localize 'ESSER.RollSkill' label=this.label}}"
-            >🎲</button>
-            <div class="skill-info">
-              <span class="skill-label">{{this.label}}</span>
-              <span class="skill-key">{{this.key}}</span>
+        <div class="attribute-groups">
+          {{#each skillGroups}}
+          <article class="attribute-block">
+            <header class="attribute-header">
+              <div class="attribute-meta">
+                <label class="attribute-label" for="esser-actor-attribute-{{../actor._id}}-{{this.key}}">{{this.label}}</label>
+                <select
+                  id="esser-actor-attribute-{{../actor._id}}-{{this.key}}"
+                  class="attribute-select"
+                  name="system.attributes.{{this.key}}"
+                >
+                  {{#each this.ranks}}
+                  <option value="{{this.value}}" {{#if this.selected}}selected{{/if}}>{{this.label}}</option>
+                  {{/each}}
+                </select>
+              </div>
+              <p class="attribute-description">{{this.description}}</p>
+            </header>
+            <div class="skills-grid">
+              {{#each this.skills}}
+              <div class="skill-row">
+                <button
+                  type="button"
+                  class="roll-button"
+                  data-action="roll-skill"
+                  data-skill="{{this.key}}"
+                  aria-label="{{localize 'ESSER.RollSkill' label=this.label}}"
+                >🎲</button>
+                <div class="skill-info">
+                  <span class="skill-label">{{this.label}}</span>
+                  <span class="skill-key">{{this.key}}</span>
+                </div>
+                <select class="skill-select" name="system.skills.{{this.key}}">
+                  {{#each this.ranks}}
+                  <option value="{{this.value}}" {{#if this.selected}}selected{{/if}}>{{this.label}}</option>
+                  {{/each}}
+                </select>
+              </div>
+              {{/each}}
             </div>
-            <input
-              class="skill-input"
-              type="number"
-              name="system.skills.{{this.key}}"
-              value="{{lookup ../system.skills this.key}}"
-            />
-          </div>
+          </article>
           {{/each}}
         </div>
       </section>


### PR DESCRIPTION
## Summary
- add Might, Agility, Mind, and Charm attributes with default modifiers
- group skills beneath their governing attribute and switch bonuses to rank dropdowns
- enable sheet scrolling and bump the system version to 0.1.7

## Testing
- Not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68e040f9028c8328ba138c9c87549bd0