### PR TITLE
Lighten strikes panel background

### DIFF
--- a/esser/styles/esser.css
+++ b/esser/styles/esser.css
@@ -141,10 +141,10 @@
   grid-template-rows: auto auto auto;
   gap: 8px;
   align-content: start;
-  background: rgba(249, 115, 22, 0.08);
+  background: rgba(255, 255, 255, 0.95);
   border-radius: 12px;
   padding: 12px 14px;
-  box-shadow: inset 0 0 0 1px rgba(249, 115, 22, 0.12);
+  box-shadow: inset 0 0 0 1px rgba(249, 115, 22, 0.18), 0 2px 6px rgba(15, 23, 42, 0.08);
 }
 
 .panel-label {

--- a/esser/system.json
+++ b/esser/system.json
@@ -2,7 +2,7 @@
   "id": "esser",
   "title": "ESSER – Espen’s Super Simple Easy RPG",
   "description": "A rules-light, theatre-of-the-mind RPG system for Foundry VTT. d20 + bonuses, Strikes, and simple opposed combat.",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "compatibility": { "minimum": "13", "verified": "13" },
   "authors": [{ "name": "Espen + Codex" }],
   "url": "https://example.com/esser",


### PR DESCRIPTION
## Summary
- lighten the strikes panel styling to use a near-white background with a subtle accent shadow
- bump the system manifest version to 0.1.10 for the new styling update

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e04bbbe6348328b09626fe0d26fc63