### PR TITLE
Fix skill rank bonus handling and bump version to 0.1.10

### DIFF
--- a/esser/module/esser.js
+++ b/esser/module/esser.js
@@ -177,14 +177,15 @@ function prepareAttributeGroups(actor, attributeOptions, skillOptions) {
       })),
       skills: def.skills.map((skillKey) => {
         const skillLabel = localizeOrFallback(`ESSER.Skill.${skillKey}`, SKILL_LABELS[skillKey] ?? skillKey);
-        const skillValue = Number(actor.system.skills?.[skillKey] ?? 0);
+        const skillRaw = actor.system.skills?.[skillKey];
+        const { bonus: skillValue, found: hasSkillValue } = extractSkillBonus(skillRaw);
         return {
           key: skillKey,
           label: skillLabel,
-          value: skillValue,
+          value: hasSkillValue ? skillValue : 0,
           ranks: skillOptions.map((option) => ({
             ...option,
-            selected: option.value === skillValue
+            selected: option.value === (hasSkillValue ? skillValue : 0)
           }))
         };
       })
@@ -269,12 +270,24 @@ function extractSkillBonus(value) {
   }
 
   if (typeof value === "object") {
+    let bonusTotal = 0;
+    let bonusFound = false;
     for (const key of ["bonus", "value", "rank", "score"]) {
-      if (Object.prototype.hasOwnProperty.call(value, key)) {
-        const result = extractSkillBonus(value[key]);
-        if (result.found) return result;
+      if (!Object.prototype.hasOwnProperty.call(value, key)) continue;
+
+      const result = extractSkillBonus(value[key]);
+      if (!result.found) continue;
+
+      if (key === "bonus") {
+        bonusTotal += result.bonus;
+        bonusFound = true;
+        continue;
       }
+
+      return { bonus: result.bonus + bonusTotal, found: true };
     }
+
+    if (bonusFound) return { bonus: bonusTotal, found: true };
   }
 
   return { bonus: 0, found: false };

--- a/esser/system.json
+++ b/esser/system.json
@@ -2,7 +2,7 @@
   "id": "esser",
   "title": "ESSER – Espen’s Super Simple Easy RPG",
   "description": "A rules-light, theatre-of-the-mind RPG system for Foundry VTT. d20 + bonuses, Strikes, and simple opposed combat.",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "compatibility": { "minimum": "13", "verified": "13" },
   "authors": [{ "name": "Espen + Codex" }],
   "url": "https://example.com/esser",


### PR DESCRIPTION
## Summary
- resolve skill bonus parsing so rank-based bonuses are included even when additional bonus fields are present
- ensure actor sheet skill selectors default to parsed values from rank definitions
- bump the system version to 0.1.10

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e04bac40b08328859819c98fcc711b