### PR TITLE
Fix character sheet data persistence

### DIFF
--- a/esser/module/esser.js
+++ b/esser/module/esser.js
@@ -107,6 +107,12 @@ class EsserActorSheet extends HandlebarsApplicationMixin(foundry.applications.sh
     super._attachPartListeners(partId, htmlElement, options);
     if (partId !== "sheet") return;
 
+    htmlElement.querySelectorAll("input[name], select[name], textarea[name]").forEach((element) => {
+      element.addEventListener("change", () => {
+        this.submit({ preventClose: true }).catch((error) => console.error(error));
+      });
+    });
+
     htmlElement.querySelectorAll("[data-action='roll-skill']").forEach((button) => {
       button.addEventListener("click", (event) => {
         event.preventDefault();
@@ -137,6 +143,15 @@ class EsserActorSheet extends HandlebarsApplicationMixin(foundry.applications.sh
     if (s >= maxStrikes) {
       ui.notifications.warn(`${this.actor.name} is OUT (3 Strikes).`);
     }
+  }
+
+  async _updateObject(event, formData) {
+    const raw = typeof formData?.toObject === "function"
+      ? formData.toObject()
+      : (formData?.object ?? formData);
+    const expanded = foundry.utils.expandObject(raw);
+    delete expanded._id;
+    return this.actor.update(expanded);
   }
 }
 

--- a/esser/system.json
+++ b/esser/system.json
@@ -2,7 +2,7 @@
   "id": "esser",
   "title": "ESSER – Espen’s Super Simple Easy RPG",
   "description": "A rules-light, theatre-of-the-mind RPG system for Foundry VTT. d20 + bonuses, Strikes, and simple opposed combat.",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "compatibility": { "minimum": "13", "verified": "13" },
   "authors": [{ "name": "Espen + Codex" }],
   "url": "https://example.com/esser",

--- a/esser/templates/actor/actor-sheet.hbs
+++ b/esser/templates/actor/actor-sheet.hbs
@@ -34,6 +34,7 @@
               class="strike-value"
               type="number"
               name="system.strikes"
+              data-dtype="Number"
               value="{{system.strikes}}"
               min="0"
               max="{{system.maxStrikes}}"
@@ -54,6 +55,7 @@
                 id="esser-actor-max-strikes-{{actor._id}}"
                 type="number"
                 name="system.maxStrikes"
+                data-dtype="Number"
                 value="{{system.maxStrikes}}"
                 min="1"
               />
@@ -80,6 +82,7 @@
                   id="esser-actor-attribute-{{../actor._id}}-{{this.key}}"
                   class="attribute-select"
                   name="system.attributes.{{this.key}}"
+                  data-dtype="Number"
                 >
                   {{#each this.ranks}}
                   <option value="{{this.value}}" {{#if this.selected}}selected{{/if}}>{{this.label}}</option>
@@ -102,7 +105,7 @@
                   <span class="skill-label">{{this.label}}</span>
                   <span class="skill-key">{{this.key}}</span>
                 </div>
-                <select class="skill-select" name="system.skills.{{this.key}}">
+                <select class="skill-select" name="system.skills.{{this.key}}" data-dtype="Number">
                   {{#each this.ranks}}
                   <option value="{{this.value}}" {{#if this.selected}}selected{{/if}}>{{this.label}}</option>
                   {{/each}}


### PR DESCRIPTION
## Summary
- ensure the actor sheet submits field changes so character updates persist
- add numeric data types for strike, attribute, and skill fields to save correct values
- bump the system version to 0.1.10

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68e04be72f5c8328b3501a74ed1d1f63