### PR TITLE
Ensure actor sheet can access document context

### DIFF
--- a/esser/module/esser.js
+++ b/esser/module/esser.js
@@ -96,6 +96,7 @@ class EsserActorSheet extends HandlebarsApplicationMixin(foundry.applications.sh
 
   async _prepareContext(options) {
     const ctx = await super._prepareContext(options);
+    ctx.actor = this.actor;
     ctx.system = this.actor.system;
     const attributeOptions = attributeRankOptions();
     const skillOptions = skillRankOptions();

--- a/esser/system.json
+++ b/esser/system.json
@@ -2,7 +2,7 @@
   "id": "esser",
   "title": "ESSER – Espen’s Super Simple Easy RPG",
   "description": "A rules-light, theatre-of-the-mind RPG system for Foundry VTT. d20 + bonuses, Strikes, and simple opposed combat.",
-  "version": "0.1.11",
+  "version": "0.1.12",
   "compatibility": { "minimum": "13", "verified": "13" },
   "authors": [{ "name": "Espen + Codex" }],
   "url": "https://example.com/esser",


### PR DESCRIPTION
## Summary
- expose the actor document on the sheet rendering context so bound fields display stored values
- bump the system manifest version to 0.1.12

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68e053123bfc83289db4f3af8d1a2225