### PR TITLE
Lighten strike input backgrounds

### DIFF
--- a/esser/styles/esser.css
+++ b/esser/styles/esser.css
@@ -190,6 +190,8 @@
   border: 1px solid rgba(15, 23, 42, 0.12);
   border-radius: 8px;
   padding: 4px;
+  background: rgba(255, 255, 255, 0.92);
+  box-shadow: inset 0 1px 2px rgba(15, 23, 42, 0.08);
 }
 
 .strike-meter {
@@ -236,6 +238,16 @@
   border-radius: 8px;
   padding: 4px;
   font-weight: 600;
+  background: rgba(255, 255, 255, 0.92);
+  box-shadow: inset 0 1px 2px rgba(15, 23, 42, 0.08);
+}
+
+.strike-value:focus,
+.max-strikes input:focus {
+  outline: none;
+  border-color: rgba(249, 115, 22, 0.5);
+  box-shadow: 0 0 0 2px rgba(249, 115, 22, 0.15), inset 0 1px 2px rgba(15, 23, 42, 0.12);
+  background: rgba(255, 255, 255, 0.98);
 }
 
 .strike-count {

--- a/esser/system.json
+++ b/esser/system.json
@@ -2,7 +2,7 @@
   "id": "esser",
   "title": "ESSER – Espen’s Super Simple Easy RPG",
   "description": "A rules-light, theatre-of-the-mind RPG system for Foundry VTT. d20 + bonuses, Strikes, and simple opposed combat.",
-  "version": "0.1.12",
+  "version": "0.1.13",
   "compatibility": { "minimum": "13", "verified": "13" },
   "authors": [{ "name": "Espen + Codex" }],
   "url": "https://example.com/esser",


### PR DESCRIPTION
## Summary
- lighten the strike adjustment and maximum strike inputs to improve readability
- add a highlighted focus state for the strike controls
- bump the system manifest version to 0.1.13

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e0568f4764832886009dc56bfd0dd8