### PR TITLE
Add overlay portrait pop-out to actor sheet

### DIFF
--- a/esser/lang/en.json
+++ b/esser/lang/en.json
@@ -10,6 +10,7 @@
   "ESSER.NotesPlaceholder": "Background beats, allies, goals, scars, and reminders all live here.",
   "ESSER.CharacterName": "Character Name",
   "ESSER.CharacterPortrait": "Click to change portrait",
+  "ESSER.ViewPortrait": "View large portrait",
   "ESSER.PortraitPromptHint": "Paste an image URL or upload a file to represent your character.",
   "ESSER.ImagePath": "Image Path",
   "ESSER.Confirm": "Confirm",

--- a/esser/module/esser.js
+++ b/esser/module/esser.js
@@ -138,6 +138,10 @@ class EsserActorSheet extends HandlebarsApplicationMixin(foundry.applications.sh
       button.addEventListener("click", (event) => this._onEditActorImage(event));
     });
 
+    htmlElement.querySelectorAll("[data-action='view-image']").forEach((button) => {
+      button.addEventListener("click", (event) => this._onViewActorImage(event));
+    });
+
     htmlElement.querySelectorAll("[data-action='strike-inc']").forEach((button) => {
       button.addEventListener("click", (event) => {
         event.preventDefault();
@@ -199,6 +203,26 @@ class EsserActorSheet extends HandlebarsApplicationMixin(foundry.applications.sh
     }
 
     return this._fallbackImagePrompt(editPath, current);
+  }
+
+  async _onViewActorImage(event) {
+    event.preventDefault();
+
+    const img = this.actor?.img;
+    if (!img) return;
+
+    const title = this.actor?.name ?? game.i18n.localize?.("ESSER.CharacterPortrait") ?? "Portrait";
+
+    const ImagePopoutCls = foundry?.applications?.api?.ImagePopout
+      ?? globalThis.ImagePopout
+      ?? foundry?.applications?.apps?.ImagePopout;
+
+    if (typeof ImagePopoutCls === "function") {
+      const popout = new ImagePopoutCls(img, { title });
+      return popout.render(true);
+    }
+
+    return window.open(img, "_blank", "noopener");
   }
 
   async _fallbackImagePrompt(editPath, current) {

--- a/esser/styles/esser.css
+++ b/esser/styles/esser.css
@@ -79,6 +79,7 @@
   align-items: center;
   justify-content: center;
   box-shadow: inset 0 0 0 1px rgba(15, 23, 42, 0.08);
+  position: relative;
 }
 
 .portrait-button {
@@ -106,6 +107,38 @@
   cursor: pointer;
   box-shadow: 0 8px 18px rgba(15, 23, 42, 0.25);
   transition: transform 150ms ease, box-shadow 150ms ease;
+}
+
+.portrait-viewer {
+  position: absolute;
+  top: 14px;
+  right: 14px;
+  width: 30px;
+  height: 30px;
+  border: none;
+  border-radius: 50%;
+  background: rgba(255, 255, 255, 0.28);
+  color: rgba(15, 23, 42, 0.6);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  opacity: 0.1;
+  transition: opacity 150ms ease, transform 150ms ease, background 150ms ease;
+  padding: 0;
+  line-height: 1;
+  z-index: 2;
+}
+
+.portrait-viewer:hover,
+.portrait-viewer:focus-visible {
+  opacity: 0.85;
+  background: rgba(255, 255, 255, 0.4);
+  transform: translateY(-1px);
+}
+
+.portrait-viewer span {
+  font-size: 0.9rem;
 }
 
 .portrait-button:hover img,

--- a/esser/system.json
+++ b/esser/system.json
@@ -2,7 +2,7 @@
   "id": "esser",
   "title": "ESSER – Espen’s Super Simple Easy RPG",
   "description": "A rules-light, theatre-of-the-mind RPG system for Foundry VTT. d20 + bonuses, Strikes, and simple opposed combat.",
-  "version": "0.1.14",
+  "version": "0.1.15",
   "compatibility": { "minimum": "13", "verified": "13" },
   "authors": [{ "name": "Espen + Codex" }],
   "url": "https://example.com/esser",

--- a/esser/templates/actor/actor-sheet.hbs
+++ b/esser/templates/actor/actor-sheet.hbs
@@ -13,6 +13,15 @@
           >
             <img src="{{actor.img}}" alt="{{actor.name}}" />
           </button>
+          <button
+            type="button"
+            class="portrait-viewer"
+            data-action="view-image"
+            aria-label="{{localize 'ESSER.ViewPortrait'}}"
+            title="{{localize 'ESSER.ViewPortrait'}}"
+          >
+            <span aria-hidden="true">🖼️</span>
+          </button>
         </div>
         <div class="identity">
           <label class="field-label" for="esser-actor-name-{{actor._id}}">{{localize "ESSER.CharacterName"}}</label>


### PR DESCRIPTION
## Summary
- add an overlay viewer control to actor portraits so users can open a large image view
- style the portrait viewer button and add localization for its tooltip text
- bump the system manifest version to 0.1.15

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68e05f2ab4088328a0fa3a2547000481