### PR TITLE
Add streamlined NPC sheet with signature skill rolls

### DIFF
--- a/esser/lang/en.json
+++ b/esser/lang/en.json
@@ -43,5 +43,27 @@
     "skilled": "Skilled (+2)",
     "expert": "Expert (+4)",
     "master": "Master (+6)"
+  },
+  "ESSER.NPC": {
+    "Tier": "Tier",
+    "TierPlaceholder": "Tier I, II, Elite...",
+    "BaseBonus": "Base Bonus",
+    "CoreTrait": "Core Trait",
+    "CoreTraitPlaceholder": "Pack tactics, rusted armor, venomous bite...",
+    "CopySummary": "Copy summary",
+    "ConceptPlaceholder": "How they fight, move, bargain, or menace.",
+    "SignatureSkills": "Signature Skills",
+    "SignatureHint": "Pick the few checks this foe shines at. Rolls add the base bonus plus the extra listed here.",
+    "Skill": "Skill",
+    "SelectSkill": "Select a skill",
+    "ExtraBonus": "Extra Bonus",
+    "TotalBonus": "Total Bonus",
+    "Roll": "Roll",
+    "Opposed": "Opposed",
+    "NotesPlaceholder": "Weak spots, tactics, treasure, or battlefield details.",
+    "SummaryCopied": "Summary copied to clipboard.",
+    "CopyFailed": "Could not copy summary. Copy it manually.",
+    "NoSkillSelected": "Choose a skill before rolling.",
+    "TargetRequired": "Target a defender token for the opposed check."
   }
 }

--- a/esser/styles/esser.css
+++ b/esser/styles/esser.css
@@ -198,6 +198,231 @@
   box-shadow: inset 0 0 0 1px rgba(249, 115, 22, 0.18), 0 2px 6px rgba(15, 23, 42, 0.08);
 }
 
+/* NPC Sheet -------------------------------------------------- */
+.esser.sheet.actor.npc .npc-header {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  padding: 18px;
+  background: linear-gradient(160deg, rgba(255, 255, 255, 0.95), rgba(191, 219, 254, 0.45));
+}
+
+.esser.sheet.actor.npc .npc-header-grid {
+  display: grid;
+  grid-template-columns: minmax(110px, 140px) 1fr minmax(200px, 220px);
+  gap: 16px;
+  align-items: stretch;
+}
+
+.esser.sheet.actor.npc .npc-portrait {
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(15, 23, 42, 0.05);
+  border-radius: 14px;
+  padding: 8px;
+  box-shadow: inset 0 0 0 1px rgba(15, 23, 42, 0.08);
+}
+
+.esser.sheet.actor.npc .npc-portrait .portrait-button img {
+  aspect-ratio: 1 / 1;
+}
+
+.esser.sheet.actor.npc .npc-identity {
+  display: grid;
+  gap: 10px;
+  align-content: start;
+}
+
+.esser.sheet.actor.npc .npc-name {
+  font-size: 1.45rem;
+  font-weight: 600;
+  border: none;
+  border-bottom: 2px solid rgba(15, 23, 42, 0.15);
+  padding: 4px 2px;
+  background: transparent;
+}
+
+.esser.sheet.actor.npc .npc-fields {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 12px;
+}
+
+.esser.sheet.actor.npc .npc-field input {
+  width: 100%;
+  border: none;
+  border-bottom: 1px solid rgba(15, 23, 42, 0.15);
+  padding: 6px 4px;
+  background: rgba(255, 255, 255, 0.65);
+  border-radius: 6px 6px 0 0;
+}
+
+.esser.sheet.actor.npc .npc-strikes {
+  display: grid;
+  grid-template-rows: auto auto auto;
+  gap: 8px;
+  align-content: start;
+  background: rgba(255, 255, 255, 0.92);
+  border-radius: 14px;
+  padding: 14px;
+  box-shadow: inset 0 0 0 1px rgba(59, 130, 246, 0.18), 0 2px 6px rgba(15, 23, 42, 0.08);
+}
+
+.esser.sheet.actor.npc .npc-summary {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 12px 16px;
+  background: rgba(15, 23, 42, 0.05);
+  border-radius: 12px;
+}
+
+.esser.sheet.actor.npc .npc-summary-text {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  font-size: 0.95rem;
+  line-height: 1.45;
+}
+
+.esser.sheet.actor.npc .copy-summary {
+  align-self: stretch;
+  padding: 8px 14px;
+  border: none;
+  border-radius: 10px;
+  background: var(--esser-accent);
+  color: #fff;
+  font-weight: 600;
+  cursor: pointer;
+  transition: transform 120ms ease, box-shadow 120ms ease;
+}
+
+.esser.sheet.actor.npc .copy-summary:hover,
+.esser.sheet.actor.npc .copy-summary:focus-visible {
+  transform: translateY(-1px);
+  box-shadow: 0 6px 14px rgba(249, 115, 22, 0.25);
+}
+
+.esser.sheet.actor.npc .npc-concept textarea {
+  width: 100%;
+  border: 1px solid rgba(15, 23, 42, 0.12);
+  border-radius: 10px;
+  padding: 10px;
+  background: rgba(255, 255, 255, 0.9);
+  resize: vertical;
+}
+
+.esser.sheet.actor.npc .npc-content {
+  display: grid;
+  grid-template-columns: minmax(0, 2fr) minmax(0, 1fr);
+  gap: 14px;
+}
+
+.esser.sheet.actor.npc .npc-focus .section-header {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  margin-bottom: 10px;
+}
+
+.esser.sheet.actor.npc .npc-focus-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.esser.sheet.actor.npc .npc-focus-row {
+  display: grid;
+  grid-template-columns: minmax(0, 1.6fr) minmax(0, 0.9fr) minmax(0, 0.6fr) minmax(0, 0.6fr);
+  gap: 10px;
+  align-items: center;
+  padding: 10px;
+  border-radius: 10px;
+  background: rgba(15, 23, 42, 0.04);
+}
+
+.esser.sheet.actor.npc .npc-focus-row select,
+.esser.sheet.actor.npc .npc-focus-row input {
+  width: 100%;
+  padding: 6px 8px;
+  border-radius: 8px;
+  border: 1px solid rgba(15, 23, 42, 0.15);
+  background: rgba(255, 255, 255, 0.9);
+}
+
+.esser.sheet.actor.npc .focus-total {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 4px;
+}
+
+.esser.sheet.actor.npc .focus-actions {
+  display: flex;
+  gap: 6px;
+  justify-content: flex-end;
+}
+
+.esser.sheet.actor.npc .focus-actions button {
+  width: 36px;
+  height: 36px;
+  border-radius: 50%;
+  border: none;
+  background: rgba(255, 255, 255, 0.95);
+  box-shadow: 0 2px 6px rgba(15, 23, 42, 0.14);
+  cursor: pointer;
+  font-size: 1.1rem;
+  transition: transform 120ms ease, box-shadow 120ms ease;
+}
+
+.esser.sheet.actor.npc .focus-actions button:disabled {
+  cursor: not-allowed;
+  opacity: 0.45;
+  box-shadow: none;
+}
+
+.esser.sheet.actor.npc .focus-actions button:not(:disabled):hover,
+.esser.sheet.actor.npc .focus-actions button:not(:disabled):focus-visible {
+  transform: translateY(-1px);
+  box-shadow: 0 6px 14px rgba(15, 23, 42, 0.22);
+}
+
+.esser.sheet.actor.npc .npc-notes textarea {
+  width: 100%;
+  min-height: 220px;
+  border-radius: 12px;
+  border: 1px solid rgba(15, 23, 42, 0.12);
+  padding: 10px;
+  background: rgba(255, 255, 255, 0.95);
+}
+
+@media (max-width: 900px) {
+  .esser.sheet.actor.npc .npc-header-grid {
+    grid-template-columns: minmax(100px, 120px) 1fr;
+    grid-template-areas:
+      "portrait identity"
+      "strikes strikes";
+  }
+
+  .esser.sheet.actor.npc .npc-strikes {
+    grid-column: span 2;
+  }
+
+  .esser.sheet.actor.npc .npc-content {
+    grid-template-columns: 1fr;
+  }
+
+  .esser.sheet.actor.npc .npc-focus-row {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
 .panel-label {
   font-weight: 700;
   font-size: 1.1rem;

--- a/esser/system.json
+++ b/esser/system.json
@@ -2,7 +2,7 @@
   "id": "esser",
   "title": "ESSER – Espen’s Super Simple Easy RPG",
   "description": "A rules-light, theatre-of-the-mind RPG system for Foundry VTT. d20 + bonuses, Strikes, and simple opposed combat.",
-  "version": "0.1.15",
+  "version": "0.1.16",
   "compatibility": { "minimum": "13", "verified": "13" },
   "authors": [{ "name": "Espen + Codex" }],
   "url": "https://example.com/esser",

--- a/esser/template.json
+++ b/esser/template.json
@@ -1,6 +1,6 @@
 {
   "Actor": {
-    "types": ["character"],
+    "types": ["character", "npc"],
     "templates": {
       "base": {
         "concept": "",
@@ -22,7 +22,24 @@
         }
       }
     },
-    "character": { "templates": ["base"] }
+    "character": { "templates": ["base"] },
+    "npc": {
+      "concept": "",
+      "notes": "",
+      "tier": "Standard", 
+      "bonus": 2,
+      "coreTrait": "",
+      "strikes": 0,
+      "maxStrikes": 3,
+      "focus": {
+        "slots": [
+          { "skill": "melee", "extra": 0 },
+          { "skill": "ranged", "extra": 0 },
+          { "skill": "perception", "extra": 0 },
+          { "skill": "intimidation", "extra": 0 }
+        ]
+      }
+    }
   },
   "Item": { "types": [], "templates": {} }
 }

--- a/esser/templates/actor/npc-sheet.hbs
+++ b/esser/templates/actor/npc-sheet.hbs
@@ -1,0 +1,175 @@
+<form class="esser-sheet npc-sheet {{cssClass}}" autocomplete="off">
+  <section class="sheet-body">
+    <header class="npc-header card">
+      <div class="npc-header-grid">
+        <div class="npc-portrait" aria-hidden="{{#if actor.img}}false{{else}}true{{/if}}">
+          <button
+            type="button"
+            class="portrait-button"
+            data-action="edit-image"
+            data-edit="img"
+            aria-label="{{localize 'ESSER.CharacterPortrait'}}"
+            title="{{localize 'ESSER.CharacterPortrait'}}"
+          >
+            <img src="{{actor.img}}" alt="{{actor.name}}" />
+          </button>
+          <button
+            type="button"
+            class="portrait-viewer"
+            data-action="view-image"
+            aria-label="{{localize 'ESSER.ViewPortrait'}}"
+            title="{{localize 'ESSER.ViewPortrait'}}"
+          >
+            <span aria-hidden="true">🖼️</span>
+          </button>
+        </div>
+        <div class="npc-identity">
+          <label class="field-label" for="esser-npc-name-{{actor._id}}">{{localize "ESSER.CharacterName"}}</label>
+          <input
+            id="esser-npc-name-{{actor._id}}"
+            class="npc-name"
+            name="name"
+            type="text"
+            value="{{actor.name}}"
+            placeholder="{{localize 'ESSER.CharacterName'}}"
+          />
+
+          <div class="npc-fields">
+            <label class="npc-field">
+              <span class="field-label">{{localize "ESSER.NPC.Tier"}}</span>
+              <input type="text" name="system.tier" value="{{system.tier}}" placeholder="{{localize 'ESSER.NPC.TierPlaceholder'}}" />
+            </label>
+            <label class="npc-field">
+              <span class="field-label">{{localize "ESSER.NPC.BaseBonus"}}</span>
+              <input type="number" name="system.bonus" data-dtype="Number" value="{{system.bonus}}" />
+            </label>
+            <label class="npc-field">
+              <span class="field-label">{{localize "ESSER.NPC.CoreTrait"}}</span>
+              <input type="text" name="system.coreTrait" value="{{system.coreTrait}}" placeholder="{{localize 'ESSER.NPC.CoreTraitPlaceholder'}}" />
+            </label>
+          </div>
+        </div>
+        <div class="npc-strikes">
+          <span class="panel-label">{{localize "ESSER.Strikes"}}</span>
+          <div class="strike-controls">
+            <button type="button" class="strike-button" data-action="strike-dec" aria-label="{{localize 'ESSER.ReduceStrike'}}">−</button>
+            <input
+              class="strike-value"
+              type="number"
+              name="system.strikes"
+              data-dtype="Number"
+              value="{{system.strikes}}"
+              min="0"
+              max="{{system.maxStrikes}}"
+            />
+            <button type="button" class="strike-button" data-action="strike-inc" aria-label="{{localize 'ESSER.IncreaseStrike'}}">+</button>
+          </div>
+          <meter
+            class="strike-meter"
+            min="0"
+            max="{{system.maxStrikes}}"
+            value="{{system.strikes}}"
+            title="{{system.strikes}} / {{system.maxStrikes}}"
+          ></meter>
+          <div class="strike-meta">
+            <label class="max-strikes" for="esser-npc-max-strikes-{{actor._id}}">
+              <span>{{localize "ESSER.MaxStrikes"}}</span>
+              <input
+                id="esser-npc-max-strikes-{{actor._id}}"
+                type="number"
+                name="system.maxStrikes"
+                data-dtype="Number"
+                value="{{system.maxStrikes}}"
+                min="1"
+              />
+            </label>
+            <span class="strike-count">{{system.strikes}} / {{system.maxStrikes}}</span>
+          </div>
+        </div>
+      </div>
+      <div class="npc-summary">
+        <div class="npc-summary-text">
+          <p>{{quickSummary}}</p>
+          {{#if conceptSummary}}
+          <p>{{conceptSummary}}</p>
+          {{/if}}
+        </div>
+        <button type="button" class="copy-summary" data-action="copy-summary">{{localize "ESSER.NPC.CopySummary"}}</button>
+      </div>
+      <label class="npc-concept">
+        <span class="field-label">{{localize "ESSER.Concept"}}</span>
+        <textarea
+          name="system.concept"
+          rows="2"
+          placeholder="{{localize 'ESSER.NPC.ConceptPlaceholder'}}"
+        >{{system.concept}}</textarea>
+      </label>
+    </header>
+
+    <section class="npc-content">
+      <section class="npc-focus card">
+        <header class="section-header">
+          <h2>{{localize "ESSER.NPC.SignatureSkills"}}</h2>
+          <p>{{localize "ESSER.NPC.SignatureHint"}}</p>
+        </header>
+        <ol class="npc-focus-list">
+          {{#each focusSlots}}
+          <li class="npc-focus-row">
+            <div class="focus-skill">
+              <label class="field-label" for="esser-npc-skill-{{../actor._id}}-{{this.index}}">{{localize "ESSER.NPC.Skill"}}</label>
+              <select id="esser-npc-skill-{{../actor._id}}-{{this.index}}" name="system.focus.slots.{{this.index}}.skill">
+                {{#each this.options}}
+                <option value="{{this.value}}" {{#if this.selected}}selected{{/if}}>{{this.label}}</option>
+                {{/each}}
+              </select>
+            </div>
+            <div class="focus-extra">
+              <label class="field-label" for="esser-npc-extra-{{../actor._id}}-{{this.index}}">{{localize "ESSER.NPC.ExtraBonus"}}</label>
+              <input
+                id="esser-npc-extra-{{../actor._id}}-{{this.index}}"
+                type="number"
+                name="system.focus.slots.{{this.index}}.extra"
+                data-dtype="Number"
+                value="{{this.extra}}"
+              />
+            </div>
+            <div class="focus-total">
+              <span class="field-label">{{localize "ESSER.NPC.TotalBonus"}}</span>
+              <span class="total-display">{{this.totalDisplay}}</span>
+            </div>
+            <div class="focus-actions">
+              <button
+                type="button"
+                class="roll-button"
+                data-action="npc-roll"
+                data-skill="{{this.skill}}"
+                {{#unless this.hasSkill}}disabled{{/unless}}
+                aria-label="{{localize 'ESSER.RollSkill' label=this.label}}"
+                title="{{localize 'ESSER.NPC.Roll'}} {{this.label}}"
+              >🎲</button>
+              <button
+                type="button"
+                class="oppose-button"
+                data-action="npc-opposed"
+                data-skill="{{this.skill}}"
+                {{#unless this.hasSkill}}disabled{{/unless}}
+                aria-label="{{localize 'ESSER.NPC.Opposed'}} {{this.label}}"
+                title="{{localize 'ESSER.NPC.Opposed'}} {{this.label}}"
+              >⚔️</button>
+            </div>
+          </li>
+          {{/each}}
+        </ol>
+      </section>
+
+      <aside class="npc-notes card">
+        <h2>{{localize "ESSER.Notes"}}</h2>
+        <textarea
+          name="system.notes"
+          rows="10"
+          placeholder="{{localize 'ESSER.NPC.NotesPlaceholder'}}"
+        >{{system.notes}}</textarea>
+      </aside>
+    </section>
+  </section>
+</form>


### PR DESCRIPTION
## Summary
- add an NPC/monster actor type with a focused sheet that highlights quick stats, concept, and signature skills
- implement dedicated NPC sheet logic with roll buttons, opposed checks, and clipboard-friendly summary text
- style the new sheet, supply localization strings/default data, and bump the system version

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68e0c53e33bc8328b3975b653e578a7e