### PR TITLE
Support alternate NPC stat block imports

### DIFF
--- a/esser/lang/en.json
+++ b/esser/lang/en.json
@@ -68,7 +68,7 @@
     "PasteImported": "Stat block imported successfully.",
     "PasteUnrecognized": "Could not understand the provided stat block.",
     "StatBlockHeader": "Stat Block",
-    "StatBlockHint": "Paste a summary line (or two) from your reference and we'll fill in the details.",
+    "StatBlockHint": "Paste a summary line or a two-line stat block from your reference and we'll fill in the details.",
     "StatBlockPlaceholder": "Goblin Sneak – Tier I, +2, Strikes 0/3, Pack tactics",
     "StatBlockImport": "Import stat block",
     "StatBlockShortcut": "Press Ctrl+Enter (or ⌘+Enter) after pasting to import.",

--- a/esser/system.json
+++ b/esser/system.json
@@ -2,7 +2,7 @@
   "id": "esser",
   "title": "ESSER – Espen’s Super Simple Easy RPG",
   "description": "A rules-light, theatre-of-the-mind RPG system for Foundry VTT. d20 + bonuses, Strikes, and simple opposed combat.",
-  "version": "0.1.18",
+  "version": "0.1.19",
   "compatibility": { "minimum": "13", "verified": "13" },
   "authors": [{ "name": "Espen + Codex" }],
   "url": "https://example.com/esser",


### PR DESCRIPTION
## Summary
- parse a two-line NPC stat block format so imports work with the shared example text
- recognize the alternate format when warning users and clarify the import hint copy
- bump the system manifest version to 0.1.19

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68e0ea01d44483289f14fdd06e7ecb8a