### PR TITLE
Add dedicated NPC stat block importer dialog

### DIFF
--- a/esser/lang/en.json
+++ b/esser/lang/en.json
@@ -74,6 +74,11 @@
     "StatBlockPlaceholder": "Goblin Sneak – Tier I, +2, Strikes 0/3, Pack tactics",
     "StatBlockImport": "Import stat block",
     "StatBlockShortcut": "Press Ctrl+Enter (or ⌘+Enter) after pasting to import.",
-    "StatBlockEmpty": "Paste a stat block summary before importing."
+    "StatBlockEmpty": "Paste a stat block summary before importing.",
+    "ImportDialogTitle": "Import NPC from Stat Block",
+    "ImportOpen": "Import NPC",
+    "ImportCreated": "Created a new NPC from the stat block.",
+    "ImportFailed": "Could not create an NPC from the provided stat block.",
+    "ImportedName": "Imported NPC"
   }
 }

--- a/esser/styles/esser.css
+++ b/esser/styles/esser.css
@@ -298,7 +298,8 @@
   margin: 0;
 }
 
-.esser.sheet.actor.npc .npc-import {
+.esser.sheet.actor.npc .npc-import,
+.esser.npc-importer .npc-import {
   display: flex;
   flex-direction: column;
   gap: 10px;
@@ -306,24 +307,28 @@
   border-radius: 12px;
 }
 
-.esser.sheet.actor.npc .npc-import-header {
+.esser.sheet.actor.npc .npc-import-header,
+.esser.npc-importer .npc-import-header {
   display: flex;
   flex-direction: column;
   gap: 4px;
 }
 
-.esser.sheet.actor.npc .npc-import-header h2 {
+.esser.sheet.actor.npc .npc-import-header h2,
+.esser.npc-importer .npc-import-header h2 {
   margin: 0;
   font-size: 1rem;
 }
 
-.esser.sheet.actor.npc .npc-import-header p {
+.esser.sheet.actor.npc .npc-import-header p,
+.esser.npc-importer .npc-import-header p {
   margin: 0;
   font-size: 0.9rem;
   color: rgba(15, 23, 42, 0.7);
 }
 
-.esser.sheet.actor.npc .npc-import-input {
+.esser.sheet.actor.npc .npc-import-input,
+.esser.npc-importer .npc-import-input {
   width: 100%;
   min-height: 64px;
   resize: vertical;
@@ -334,14 +339,16 @@
   font-size: 0.95rem;
 }
 
-.esser.sheet.actor.npc .npc-import-actions {
+.esser.sheet.actor.npc .npc-import-actions,
+.esser.npc-importer .npc-import-actions {
   display: flex;
   align-items: center;
   gap: 12px;
   flex-wrap: wrap;
 }
 
-.esser.sheet.actor.npc .npc-import-button {
+.esser.sheet.actor.npc .npc-import-button,
+.esser.npc-importer .npc-import-button {
   border: none;
   border-radius: 10px;
   padding: 8px 16px;
@@ -353,12 +360,15 @@
 }
 
 .esser.sheet.actor.npc .npc-import-button:hover,
-.esser.sheet.actor.npc .npc-import-button:focus-visible {
+.esser.sheet.actor.npc .npc-import-button:focus-visible,
+.esser.npc-importer .npc-import-button:hover,
+.esser.npc-importer .npc-import-button:focus-visible {
   transform: translateY(-1px);
   box-shadow: 0 6px 14px rgba(249, 115, 22, 0.25);
 }
 
-.esser.sheet.actor.npc .npc-import-hint {
+.esser.sheet.actor.npc .npc-import-hint,
+.esser.npc-importer .npc-import-hint {
   font-size: 0.85rem;
   color: rgba(15, 23, 42, 0.6);
 }

--- a/esser/system.json
+++ b/esser/system.json
@@ -2,7 +2,7 @@
   "id": "esser",
   "title": "ESSER – Espen’s Super Simple Easy RPG",
   "description": "A rules-light, theatre-of-the-mind RPG system for Foundry VTT. d20 + bonuses, Strikes, and simple opposed combat.",
-  "version": "0.1.21",
+  "version": "0.1.22",
   "compatibility": { "minimum": "13", "verified": "13" },
   "authors": [{ "name": "Espen + Codex" }],
   "url": "https://example.com/esser",

--- a/esser/templates/actor/npc-sheet.hbs
+++ b/esser/templates/actor/npc-sheet.hbs
@@ -158,25 +158,6 @@
           {{/each}}
         </ol>
       </section>
-      <section class="npc-import card">
-        <header class="npc-import-header">
-          <h2>{{localize "ESSER.NPC.StatBlockHeader"}}</h2>
-          <p>{{localize "ESSER.NPC.StatBlockHint"}}</p>
-        </header>
-        <textarea
-          class="npc-import-input"
-          data-role="npc-stat-block"
-          rows="3"
-          placeholder="{{localize 'ESSER.NPC.StatBlockPlaceholder'}}"
-          aria-label="{{localize 'ESSER.NPC.StatBlockHeader'}}"
-        ></textarea>
-        <div class="npc-import-actions">
-          <button type="button" class="npc-import-button" data-action="npc-import-stat-block">
-            {{localize "ESSER.NPC.StatBlockImport"}}
-          </button>
-          <span class="npc-import-hint">{{localize "ESSER.NPC.StatBlockShortcut"}}</span>
-        </div>
-      </section>
     </section>
   </section>
 </form>

--- a/esser/templates/apps/npc-import.hbs
+++ b/esser/templates/apps/npc-import.hbs
@@ -1,0 +1,19 @@
+<section class="npc-import card">
+  <header class="npc-import-header">
+    <h2>{{localize "ESSER.NPC.StatBlockHeader"}}</h2>
+    <p>{{localize "ESSER.NPC.StatBlockHint"}}</p>
+  </header>
+  <textarea
+    class="npc-import-input"
+    data-role="npc-stat-block"
+    rows="4"
+    placeholder="{{localize 'ESSER.NPC.StatBlockPlaceholder'}}"
+    aria-label="{{localize 'ESSER.NPC.StatBlockHeader'}}"
+  ></textarea>
+  <div class="npc-import-actions">
+    <button type="button" class="npc-import-button" data-action="npc-import-stat-block">
+      {{localize "ESSER.NPC.StatBlockImport"}}
+    </button>
+    <span class="npc-import-hint">{{localize "ESSER.NPC.StatBlockShortcut"}}</span>
+  </div>
+</section>


### PR DESCRIPTION
## Summary
- add a standalone NPC stat block importer dialog accessible from the Actor directory
- update NPC sheet helpers to share stat block parsing logic and remove the embedded importer UI
- refresh translations, styles, templates, and system version to support the new workflow

## Testing
- No automated tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68e12a6df3448328b593fc77689e8e54