### PR TITLE
Include NPC concept in NPC summary

### DIFF
--- a/esser/module/esser.js
+++ b/esser/module/esser.js
@@ -943,7 +943,11 @@ function npcSummaryLine(actor) {
   const strikes = Number(actor?.system?.strikes ?? 0);
   const maxStrikes = Number(actor?.system?.maxStrikes ?? 3);
   const coreTrait = actor?.system?.coreTrait?.trim() || game.i18n.localize("ESSER.NPC.CoreTrait");
-  return `${name} – ${tier}, ${formatModifier(baseBonus)}, Strikes ${strikes}/${maxStrikes}, ${coreTrait}`;
+  const concept = actor?.system?.concept?.trim();
+  const conceptLabel = game?.i18n?.localize?.("ESSER.Concept") ?? "Concept";
+
+  const conceptPart = concept ? `. ${conceptLabel}: ${concept}` : "";
+  return `${name} – ${tier}, ${formatModifier(baseBonus)}, Strikes ${strikes}/${maxStrikes}, ${coreTrait}${conceptPart}`;
 }
 
 function npcDataFromParsed(parsed, actor) {

--- a/esser/system.json
+++ b/esser/system.json
@@ -2,7 +2,7 @@
   "id": "esser",
   "title": "ESSER – Espen’s Super Simple Easy RPG",
   "description": "A rules-light, theatre-of-the-mind RPG system for Foundry VTT. d20 + bonuses, Strikes, and simple opposed combat.",
-  "version": "0.1.22",
+  "version": "0.1.23",
   "compatibility": { "minimum": "13", "verified": "13" },
   "authors": [{ "name": "Espen + Codex" }],
   "url": "https://example.com/esser",


### PR DESCRIPTION
## Summary
- append the NPC concept to the quick summary shown on the NPC sheet
- bump the system manifest version to 0.1.23

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68e12ee61884832883a1711009d8bc11